### PR TITLE
change precedence of function calls to not override builtins

### DIFF
--- a/syntaxes/perl.tmLanguage.json
+++ b/syntaxes/perl.tmLanguage.json
@@ -19,9 +19,6 @@
       "include": "#function_definition"
     },
     {
-      "include": "#function_call"
-    },
-    {
       "include": "#label"
     },
     {
@@ -2116,6 +2113,9 @@
     {
       "match": "\\b(ARGV|DATA|ENV|SIG|STDERR|STDIN|STDOUT|atan2|bind|binmode|bless|caller|chdir|chmod|chomp|chop|chown|chr|chroot|close|closedir|cmp|connect|cos|crypt|dbmclose|dbmopen|defined|delete|dump|each|endgrent|endhostent|endnetent|endprotoent|endpwent|endservent|eof|eq|eval|exec|exists|exp|fcntl|fileno|flock|fork|formline|ge|getc|getgrent|getgrgid|getgrnam|gethostbyaddr|gethostbyname|gethostent|getlogin|getnetbyaddr|getnetbyname|getnetent|getpeername|getpgrp|getppid|getpriority|getprotobyname|getprotobynumber|getprotoent|getpwent|getpwnam|getpwuid|getservbyname|getservbyport|getservent|getsockname|getsockopt|glob|gmtime|grep|gt|hex|import|index|int|ioctl|join|keys|kill|lc|lcfirst|le|length|link|listen|local|localtime|log|lstat|lt|m|map|mkdir|msgctl|msgget|msgrcv|msgsnd|ne|no|oct|open|opendir|ord|pack|pipe|pop|pos|print|printf|push|quotemeta|rand|read|readdir|readlink|recv|ref|rename|reset|reverse|rewinddir|rindex|rmdir|s|say|scalar|seek|seekdir|semctl|semget|semop|send|setgrent|sethostent|setnetent|setpgrp|setpriority|setprotoent|setpwent|setservent|setsockopt|shift|shmctl|shmget|shmread|shmwrite|shutdown|sin|sleep|socket|socketpair|sort|splice|split|sprintf|sqrt|srand|stat|study|substr|symlink|syscall|sysopen|sysread|system|syswrite|tell|telldir|tie|tied|time|times|tr|truncate|uc|ucfirst|umask|undef|unlink|unpack|unshift|untie|utime|values|vec|waitpid|wantarray|warn|write|y)\\b",
       "name": "support.function.perl"
+    },
+    {
+      "include": "#function_call"
     },
     {
       "captures": {


### PR DESCRIPTION
As the grammar is structured right now, `return;` is recognized correctly as a keyword, but `return();` is considered a function call. The attached change fixes the deployed file by lowering the predence of `#function_call`, to prevent these from being overridden:

```
support.function.perl (binmode, etc.)
keyword.operator.logical.perl (not, etc.)
storage.modifier.perl (my, etc.)
keyword.control.perl (exit, etc.)
```

I have had a bit of a hard time installing the deps, or figuring out how to adjust generate.rb to regenerate perl.tmLanguage.json in such a way as to effect this change, but i can confirm by way of having copied the file to `~\.vscode\extensions\jeff-hykin.better-perl-syntax-1.0.14\syntaxes` that this change seems to work correctly.

Is there any chance of actually getting this change deployed?